### PR TITLE
Janitorial cleansing of stale references

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "mentaljam-obs"]
-	path = mentaljam-obs
-	url = https://github.com/mentaljam/mentaljam-obs.git

--- a/harbour-storeman.pro
+++ b/harbour-storeman.pro
@@ -172,8 +172,6 @@ OTHER_FILES += \
     qml/models/DummyCommentsModel.qml
 
 OTHER_FILES += \
-    scripts/gha-build.sh \
-    scripts/gha-release.sh \
     scripts/update_categories.py \
     scripts/update_translators.py \
     rpm/harbour-storeman.changes \


### PR DESCRIPTION
- [Delete .gitmodules, because it became superfluous](https://github.com/storeman-developers/harbour-storeman/pull/165/commits/8aa171ed4446d1a50777864c86f2b13a1203c3d2)
  … and prevents building.

- [harbour-storeman.pro: Delete build script entries …](https://github.com/storeman-developers/harbour-storeman/pull/165/commits/fdbbb7d27d14a242b01f2b3331b0881c830454ae)
  … because there are already gone.