### PR TITLE
spec file: Depend on `libsolv`, not `libsolv0`

### DIFF
--- a/rpm/harbour-storeman.spec
+++ b/rpm/harbour-storeman.spec
@@ -11,7 +11,7 @@ Requires:       sailfishsilica-qt5
 Requires:       nemo-qml-plugin-dbus-qt5
 Requires:       nemo-qml-plugin-notifications-qt5
 Requires:       connman-qt5-declarative
-Requires:       libsolv0
+Requires:       libsolv
 Requires:       sailfishsecretsdaemon-secretsplugins-default
 BuildRequires:  pkgconfig(sailfishapp)
 BuildRequires:  pkgconfig(Qt5Core)


### PR DESCRIPTION
Fixes issue #160, is fine for SFOS ≥ 2.2.1, maybe also for ≥ 2.1.4