### PR TITLE
.pro file, line 189: Delete `repo` from `INSTALLS +=`

### DIFF
--- a/harbour-storeman.pro
+++ b/harbour-storeman.pro
@@ -186,6 +186,6 @@ privileges.path = $$INSTALL_ROOT/usr/share/mapplauncherd/privileges.d/
 dbus.files = data/harbour.storeman.service
 dbus.path = $$INSTALL_ROOT/usr/share/dbus-1/services
 
-INSTALLS += privileges dbus repo
+INSTALLS += privileges dbus
 
 include(translations/translations.pri)


### PR DESCRIPTION
…, see [harbour-storeman.pro L189](https://github.com/storeman-developers/harbour-storeman/blob/4aa3f5ddb049d60ff45d77c4400e4816a00110b4/harbour-storeman.pro#L189).