### PR TITLE
config.yml: Omit senseless `pr_branch_name:`

### DIFF
--- a/.tx/config.yml
+++ b/.tx/config.yml
@@ -5,5 +5,3 @@ git:
       source_language: en
       source_file: translations/harbour-storeman.ts
       translation_files_expression: 'translations/harbour-storeman-<lang>.ts'
-  settings:
-    pr_branch_name: devel_<br_unique_id>


### PR DESCRIPTION
…, because it does [what the documentation says](https://docs.transifex.com/transifex-github-integrations/github-tx-ui#section-yaml-configuration-parameter-descriptions): It specifies the branch name for the Pull Request, but the target branch of the PR is always the source branch!