### PR TITLE
Rename build-sfos2.2.yml to build-sfos3.1.yml and target 3.1.0.12

### DIFF
--- a/.github/workflows/build-devel.yml
+++ b/.github/workflows/build-devel.yml
@@ -1,4 +1,4 @@
-name: CI build - devel branch on SFOS 3.3.0.14 (armv7hl)
+name: CI build - devel branch for SFOS 3.3.0.14 (armv7hl)
 
 env:
   sfos_target: 3.3.0.14

--- a/.github/workflows/build-sfos3.1.yml
+++ b/.github/workflows/build-sfos3.1.yml
@@ -1,7 +1,7 @@
-name: CI build - sfos3.2 branch on SFOS 2.2.0.29 (armv7hl, i486)
+name: CI build - sfos3.2 branch for SFOS 3.1.0.12 (armv7hl, i486)
 
 env:
-  sfos_target: 2.2.0.29
+  sfos_target: 3.1.0.12
 
 on:
   push:

--- a/.github/workflows/build-sfos3.3.yml
+++ b/.github/workflows/build-sfos3.3.yml
@@ -1,4 +1,4 @@
-name: CI build - sfos3.3 branch on SFOS 3.3.0.14 (armv7hl, i486)
+name: CI build - sfos3.3 branch for SFOS 3.3.0.14 (armv7hl, i486)
 
 env:
   sfos_target: 3.3.0.14

--- a/.github/workflows/build-sfos4.2.yml
+++ b/.github/workflows/build-sfos4.2.yml
@@ -1,4 +1,4 @@
-name: CI build - sfos4.2 branch on SFOS 4.2.0.21 (aarch64, armv7hl, i486)
+name: CI build - sfos4.2 branch for SFOS 4.2.0.21 (aarch64, armv7hl, i486)
 
 env:
   sfos_target: 4.2.0.21


### PR DESCRIPTION
…,  because minimal supported SailfishOS release is 3.1.0, see issue #191.