### PR TITLE
spec file (sfos3.2): sailfish-version >= 3.1.0 < 3.3.0

### DIFF
--- a/rpm/harbour-storeman.spec
+++ b/rpm/harbour-storeman.spec
@@ -7,6 +7,8 @@ License:        MIT
 URL:            https://github.com/storeman-developers/harbour-storeman
 Source0:        %{name}-%{version}.tar.bz2
 
+Requires:       sailfish-version >= 3.1.0
+Requires:       sailfish-version  < 3.3.0
 Requires:       sailfishsilica-qt5
 Requires:       nemo-qml-plugin-dbus-qt5
 Requires:       nemo-qml-plugin-notifications-qt5


### PR DESCRIPTION
See https://github.com/storeman-developers/harbour-storeman/issues/191 .