### PR TITLE
explicitly disable sandboxing

### DIFF
--- a/harbour-storeman.desktop
+++ b/harbour-storeman.desktop
@@ -7,3 +7,6 @@ Name=Storeman
 
 [X-HarbourBackup]
 BackupPathList=.config/harbour-storeman/:.local/share/harbour-storeman/
+
+[X-Sailjail]
+Sandboxing=Disabled


### PR DESCRIPTION
Sailfish OS 4.4 enable sandboxing for all applications by default. 
But Storeman cannot work in sandbox. 
For that reason, it is necessary to explicitly disable sandboxing.