### PR TITLE
.desktop file: Trivially bail out of SailJail

### DIFF
--- a/harbour-storeman.desktop
+++ b/harbour-storeman.desktop
@@ -5,5 +5,8 @@ Icon=harbour-storeman
 Exec=harbour-storeman
 Name=Storeman
 
+[X-Sailjail]
+Sandboxing=Disabled
+
 [X-HarbourBackup]
 BackupPathList=.config/harbour-storeman/:.local/share/harbour-storeman/


### PR DESCRIPTION
… for `sfos4.2` branch only.  Supersedes #235.  Must be reverted when `sfos4.4` branch is created, see issues #236 & #246.