### PR TITLE
[harbour-storeman.qml] Eliminate last stale link

### DIFF
--- a/qml/harbour-storeman.qml
+++ b/qml/harbour-storeman.qml
@@ -150,7 +150,7 @@ ApplicationWindow
         <doc:doc>
           <doc:summary>
             Name of the page to open
-            (https://github.com/mentaljam/harbour-storeman/tree/master/qml/pages)
+            (https://github.com/storeman-developers/harbour-storeman/tree/master/qml/pages)
           </doc:summary>
         </doc:doc>
       </arg>


### PR DESCRIPTION
to https://github.com/mentaljam/harbour-storeman instead of https://github.com/storeman-developers/harbour-storeman