### PR TITLE
[Packaging] Only package qm files

### DIFF
--- a/translations/translations.pri
+++ b/translations/translations.pri
@@ -30,7 +30,7 @@ qm.CONFIG   = target_predeps no_link
 
 QMAKE_EXTRA_COMPILERS += qm
 
-translations.files = $$OUT_PWD/translations/*qm
+translations.files = $$OUT_PWD/translations/*.qm
 translations.path  = $$PREFIX/share/$$TARGET
 
 INSTALLS += translations

--- a/translations/translations.pri
+++ b/translations/translations.pri
@@ -30,7 +30,7 @@ qm.CONFIG   = target_predeps no_link
 
 QMAKE_EXTRA_COMPILERS += qm
 
-translations.files = $$OUT_PWD/translations
+translations.files = $$OUT_PWD/translations/*qm
 translations.path  = $$PREFIX/share/$$TARGET
 
 INSTALLS += translations


### PR DESCRIPTION
Before this change, Storeman rpms contained translations/README.md,
translations.pri, and .ts files, all of which are unnecessary in an
installed app.

