### PR TITLE
[LocalRpmsPage.qml] Filter for `mimeType` instead of `fileName` to select RPM files …

### DIFF
--- a/qml/pages/LocalRpmsPage.qml
+++ b/qml/pages/LocalRpmsPage.qml
@@ -19,12 +19,7 @@ Page {
         properties: ["fileName", "filePath"]
         sortProperties: ["+fileName"]
         rootType: DocumentGallery.File
-        filter: GalleryFilterUnion {
-            filters: [
-                GalleryEqualsFilter { property: "fileExtension"; value: "rpm" },
-                GalleryEqualsFilter { property: "fileExtension"; value: "RPM" }
-            ]
-        }
+        filter: GalleryEqualsFilter { property: "mimeType"; value: "application/x-rpm" }
     }
 
     SilicaListView {


### PR DESCRIPTION
… as [suggested by @pvuorela](https://github.com/storeman-developers/harbour-storeman/issues/461#issuecomment-1999185613).  Enhances PR #462, which closed issue #461.