### PR TITLE
Remove `User=` specification from D-Bus service file

### DIFF
--- a/data/harbour.storeman.service
+++ b/data/harbour.storeman.service
@@ -1,4 +1,3 @@
 [D-BUS Service]
 Name=harbour.storeman.service
 Exec=/usr/bin/invoker --type=silica-qt5 -s /usr/bin/harbour-storeman
-User=nemo


### PR DESCRIPTION
`User=` specification is only needed for "system" (i.e. system-wide) message buses, but this runs on a "session" (i.e. per-user-login-session) bus.

Fixes: #301

References: 
- [D-Bus Specification](https://dbus.freedesktop.org/doc/dbus-specification.html#id-1.13.5.11.5)
- Man-page for `dbus-daemon`, [section "configuration file"](https://dbus.freedesktop.org/doc/dbus-daemon.1.html#configuration_file) and examples in [section "integrating session services"](https://dbus.freedesktop.org/doc/dbus-daemon.1.html#session_services)