### PR TITLE
[qml/pages/AuthorisationDialog.qml] E-mail address does not seem to work …

### DIFF
--- a/qml/pages/AuthorisationDialog.qml
+++ b/qml/pages/AuthorisationDialog.qml
@@ -61,7 +61,7 @@ Dialog {
                 id: usernameField
                 width: parent.width
                 //: A translated string should not be longer than the original
-                //% "Username or e-mail address"
+                //% "Username"
                 placeholderText: qsTrId("orn-username")
                 label: placeholderText
                 validator: RegExpValidator {

--- a/qml/pages/AuthorisationDialog.qml
+++ b/qml/pages/AuthorisationDialog.qml
@@ -60,7 +60,7 @@ Dialog {
             TextField {
                 id: usernameField
                 width: parent.width
-                //: A translated string should not be longer than the original
+                //: A translated string should comprise less than 27 characters
                 //% "Username"
                 placeholderText: qsTrId("orn-username")
                 label: placeholderText

--- a/translations/harbour-storeman-cs.ts
+++ b/translations/harbour-storeman-cs.ts
@@ -407,7 +407,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Uživatelské jméno</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-cs.ts
+++ b/translations/harbour-storeman-cs.ts
@@ -406,9 +406,9 @@
         <translation>Přihlásit </translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Uživatelské jméno nebo e-mail</translation>
+        <translation>Uživatelské jméno</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman-da.ts
+++ b/translations/harbour-storeman-da.ts
@@ -404,7 +404,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-storeman-da.ts
+++ b/translations/harbour-storeman-da.ts
@@ -405,7 +405,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-de.ts
+++ b/translations/harbour-storeman-de.ts
@@ -398,7 +398,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Benutzername</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-de.ts
+++ b/translations/harbour-storeman-de.ts
@@ -397,9 +397,9 @@
         <translation>Anmelden</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Benutzername oder E-Mail-Adresse</translation>
+        <translation>Benutzername</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman-el.ts
+++ b/translations/harbour-storeman-el.ts
@@ -404,9 +404,9 @@
         <translation>Σύνδεση</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Όνομα χρήστη ή ηλεκτρονική διεύθυνση</translation>
+        <translation>Όνομα χρήστη</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman-el.ts
+++ b/translations/harbour-storeman-el.ts
@@ -405,7 +405,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Όνομα χρήστη</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-es.ts
+++ b/translations/harbour-storeman-es.ts
@@ -397,7 +397,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Nombre de usuario</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-es.ts
+++ b/translations/harbour-storeman-es.ts
@@ -396,9 +396,9 @@
         <translation>Iniciar sesión</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Nombre de usuario o correo</translation>
+        <translation>Nombre de usuario</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman-et.ts
+++ b/translations/harbour-storeman-et.ts
@@ -398,7 +398,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Kasutajanimi</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-et.ts
+++ b/translations/harbour-storeman-et.ts
@@ -397,9 +397,9 @@
         <translation>Logi sisse</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Kasutajanimi või e-post</translation>
+        <translation>Kasutajanimi</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman-fi.ts
+++ b/translations/harbour-storeman-fi.ts
@@ -404,9 +404,9 @@
         <translation>Kirjaudu sisään</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Käyttäjänimi tai sähköposti</translation>
+        <translation>Käyttäjänimi</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman-fi.ts
+++ b/translations/harbour-storeman-fi.ts
@@ -405,7 +405,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Käyttäjänimi</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-fr.ts
+++ b/translations/harbour-storeman-fr.ts
@@ -397,9 +397,9 @@
         <translation>Connexion</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Nom d&apos;utilisateur ou adresse mail</translation>
+        <translation>Nom d&apos;utilisateur</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman-fr.ts
+++ b/translations/harbour-storeman-fr.ts
@@ -398,7 +398,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Nom d&apos;utilisateur</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-hu.ts
+++ b/translations/harbour-storeman-hu.ts
@@ -397,7 +397,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Felhasználónév</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-hu.ts
+++ b/translations/harbour-storeman-hu.ts
@@ -396,7 +396,7 @@
         <translation>Bejelentkezés</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
         <translation>Felhasználónév</translation>
     </message>

--- a/translations/harbour-storeman-it.ts
+++ b/translations/harbour-storeman-it.ts
@@ -405,7 +405,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Nome utente</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-it.ts
+++ b/translations/harbour-storeman-it.ts
@@ -404,9 +404,9 @@
         <translation>Accedi</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Nome utente o indirizzo email</translation>
+        <translation>Nome utente</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman-nl.ts
+++ b/translations/harbour-storeman-nl.ts
@@ -404,9 +404,9 @@
         <translation>Aanmelden</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Gebruikersnaam of e-mailadres</translation>
+        <translation>Gebruikersnaam</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman-nl.ts
+++ b/translations/harbour-storeman-nl.ts
@@ -405,7 +405,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Gebruikersnaam</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-nl_BE.ts
+++ b/translations/harbour-storeman-nl_BE.ts
@@ -404,9 +404,9 @@
         <translation>Aanmelden</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Gebruikersnaam of e-mailadres</translation>
+        <translation>Gebruikersnaam</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman-nl_BE.ts
+++ b/translations/harbour-storeman-nl_BE.ts
@@ -405,7 +405,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Gebruikersnaam</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-no.ts
+++ b/translations/harbour-storeman-no.ts
@@ -404,9 +404,9 @@
         <translation>Logg inn</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Brukernavn eller epostadresse</translation>
+        <translation>Brukernavn</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman-no.ts
+++ b/translations/harbour-storeman-no.ts
@@ -405,7 +405,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Brukernavn</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-pl.ts
+++ b/translations/harbour-storeman-pl.ts
@@ -406,9 +406,9 @@
         <translation>Zaloguj</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Nazwa użytkownika lub adres email</translation>
+        <translation>Nazwa użytkownika</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman-pl.ts
+++ b/translations/harbour-storeman-pl.ts
@@ -407,7 +407,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Nazwa użytkownika</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-pt.ts
+++ b/translations/harbour-storeman-pt.ts
@@ -404,9 +404,9 @@
         <translation>Log in</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Usuário ou e-mail</translation>
+        <translation>Usuário</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman-pt.ts
+++ b/translations/harbour-storeman-pt.ts
@@ -405,7 +405,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Usuário</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-ru.ts
+++ b/translations/harbour-storeman-ru.ts
@@ -397,7 +397,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Имя пользователя</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-ru.ts
+++ b/translations/harbour-storeman-ru.ts
@@ -396,9 +396,9 @@
         <translation>Войти</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Имя пользователя или email</translation>
+        <translation>Имя пользователя</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman-sk.ts
+++ b/translations/harbour-storeman-sk.ts
@@ -398,7 +398,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Meno používateľa</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-sk.ts
+++ b/translations/harbour-storeman-sk.ts
@@ -397,9 +397,9 @@
         <translation>Prihlásiť sa</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Meno používateľa alebo e-mail</translation>
+        <translation>Meno používateľa</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman-sl.ts
+++ b/translations/harbour-storeman-sl.ts
@@ -398,7 +398,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Uporabniško ime</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-sl.ts
+++ b/translations/harbour-storeman-sl.ts
@@ -397,9 +397,9 @@
         <translation>Prijava</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Uporabniško ime ali e-poštni naslov</translation>
+        <translation>Uporabniško ime</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman-sv.ts
+++ b/translations/harbour-storeman-sv.ts
@@ -398,7 +398,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should be less than 26 characters long</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Användarnamn</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman-sv.ts
+++ b/translations/harbour-storeman-sv.ts
@@ -397,9 +397,9 @@
         <translation>Lösenord</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Användarnamn eller e-postadress</translation>
+        <source>Username</source>
+        <extracomment>A translated string should be less than 26 characters long</extracomment>
+        <translation>Användarnamn</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman-tt.ts
+++ b/translations/harbour-storeman-tt.ts
@@ -396,9 +396,9 @@
         <translation>Керү</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Кулланучы исеме я e-mail</translation>
+        <source>Username</source>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
+        <translation>Кулланучы исеме</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman-zh.ts
+++ b/translations/harbour-storeman-zh.ts
@@ -402,9 +402,9 @@
         <translation>登录</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>用户名称或邮箱地址</translation>
+        <source>Username</source>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
+        <translation>用户名</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>

--- a/translations/harbour-storeman.ts
+++ b/translations/harbour-storeman.ts
@@ -406,7 +406,7 @@
     </message>
     <message id="orn-username">
         <source>Username</source>
-        <extracomment>A translated string should not be longer than the original</extracomment>
+        <extracomment>A translated string should comprise less than 27 characters</extracomment>
         <translation>Username</translation>
     </message>
     <message id="orn-login-help">

--- a/translations/harbour-storeman.ts
+++ b/translations/harbour-storeman.ts
@@ -405,9 +405,9 @@
         <translation>Log in</translation>
     </message>
     <message id="orn-username">
-        <source>Username or e-mail address</source>
+        <source>Username</source>
         <extracomment>A translated string should not be longer than the original</extracomment>
-        <translation>Username or e-mail address</translation>
+        <translation>Username</translation>
     </message>
     <message id="orn-login-help">
         <source>Log in to OpenRepos.net to comment applications and reply to others comments.&lt;br /&gt;&lt;br /&gt;Storeman does not send your password to third-parties.</source>


### PR DESCRIPTION
…, though it should: OpenRepos' web-frontend allows for both, either an OpenRepos user-name or its e-mail address, and AFAIK the OpenRepos API documentation states that; still only the user-name seems to work when using the web-API.

Also updating `<extracomment>` for `orn-username` in all TS-files as a consequence.