### PR TITLE
[build-sfos4.2_latest.yml] Lower LATEST to "SDK for SFOS 4.3.0" …

### DIFF
--- a/.github/workflows/build-sfos4.2_latest.yml
+++ b/.github/workflows/build-sfos4.2_latest.yml
@@ -1,8 +1,11 @@
 name: CI - sfos4.2 branch on latest SDK (aarch64,armv7hl,i486)
 
 env:
-  # For the latest available docker image, see https://github.com/CODeRUS/docker-sailfishos-platform-sdk
-  RELEASE: 5.0.0.43
+  # For the available docker images, see https://github.com/CODeRUS/docker-sailfishos-platform-sdk
+  # But LATEST means here, "known to run on the latest SailfishOS release": Binaries for 4.3.0 are known to run on 5.0.0.
+  RELEASE: 4.3.0.12
+  # When LATEST has to be raised (e.g. to "RELEASE: 5.0.0.43"), create a new, separate workflow configuration file for 4.3.0,
+  # named: `build-sfos4.2_sdk4.3.yml` / "CI - sfos4.2 branch on SDK for 4.3.0 (aarch64,armv7hl,i486)"
 
 on:
   push:


### PR DESCRIPTION
…, because this is the "oldest common denominator" known to generate binaries which run on the current SailfishOS release (as of now: SFOS 5.0.0).